### PR TITLE
Deprecate Missings.skip in favor of skipmissing

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -4,7 +4,7 @@ module Missings
 import Base: *, <, ==, !=, <=, !, +, -, ^, /, &, |, xor
 using Compat: AbstractRange
 
-export ismissing, missing, missings, Missing, MissingException, levels
+export ismissing, missing, missings, Missing, MissingException, levels, skipmissing
 
 """
     Missing
@@ -152,7 +152,7 @@ Return an iterator wrapping iterable `itr` which replaces [`missing`](@ref) valu
 If the type of `replacement` differs from the element type of `itr`,
 it will be converted.
 
-See also: [`Missings.skip`](@ref), [`Missings.fail`](@ref)
+See also: [`skipmissing`](@ref), [`Missings.fail`](@ref)
 
 # Examples
 ```jldoctest
@@ -189,7 +189,7 @@ Base.eltype(itr::EachReplaceMissing) = Missings.T(eltype(itr.x))
 end
 
 """
-    Missings.skip(itr)
+    skipmissing(itr)
 
 Return an iterator wrapping iterable `itr` which skips [`missing`](@ref) values.
 
@@ -198,23 +198,22 @@ Use [`collect`](@ref) to obtain an `Array` containing the non-`missing` values i
 be a `Vector` since it is not possible to remove missings while preserving dimensions
 of the input.
 
-See also: [`Missings.replace`](@ref), [`Missings.fail`](@ref)
-
 # Examples
 ```jldoctest
-julia> collect(Missings.skip([1, missing, 2]))
+julia> collect(skipmissing([1, missing, 2]))
 2-element Array{Int64,1}:
  1
  2
 
-julia> collect(Missings.skip([1 missing; 2 missing]))
+julia> collect(skipmissing([1 missing; 2 missing]))
 2-element Array{Int64,1}:
  1
  2
 
 ```
 """
-skip(itr) = EachSkipMissing(itr)
+skipmissing(itr) = EachSkipMissing(itr)
+
 struct EachSkipMissing{T}
     x::T
 end
@@ -276,7 +275,7 @@ if a [`missing`](@ref) value is found.
 Use [`collect`](@ref) to obtain an `Array` containing the resulting values.
 If `itr` is an array, the resulting array will have the same dimensions.
 
-See also: [`Missings.skip`](@ref), [`Missings.replace`](@ref)
+See also: [`skipmissing`](@ref), [`Missings.replace`](@ref)
 
 # Examples
 ```jldoctest
@@ -426,5 +425,8 @@ function Base.float(A::AbstractArray{Union{T, Missing}}) where {T}
     convert(AbstractArray{Union{U, Missing}}, A)
 end
 Base.float(A::AbstractArray{Missing}) = A
+
+# Deprecations
+@deprecate skip(itr) skipmissing(itr)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,27 +176,27 @@ using Base.Test, Missings
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
 
-    x = Missings.skip([1, 2, missing, 4])
+    x = skipmissing([1, 2, missing, 4])
     @test eltype(x) === Int
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
-    x = Missings.skip([1  2; missing 4])
+    x = skipmissing([1  2; missing 4])
     @test eltype(x) === Int
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
-    x = collect(Missings.skip([missing]))
+    x = collect(skipmissing([missing]))
     @test eltype(x) === Union{}
     @test isempty(collect(x))
     @test collect(x) isa Vector{Union{}}
-    x = collect(Missings.skip(Union{Int, Missing}[]))
+    x = collect(skipmissing(Union{Int, Missing}[]))
     @test eltype(x) === Int
     @test isempty(collect(x))
     @test collect(x) isa Vector{Int}
-    x = Missings.skip([missing, missing, 1, 2, missing, 4, missing, missing])
+    x = skipmissing([missing, missing, 1, 2, missing, 4, missing, missing])
     @test eltype(x) === Int
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
-    x = Missings.skip(v for v in [missing, 1, missing, 2, 4])
+    x = skipmissing(v for v in [missing, 1, missing, 2, 4])
     @test eltype(x) === Any
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}


### PR DESCRIPTION
With the inclusion in Base, there will not necessarily be a `Missings` module (and there are not many fans of this name anyway), so better use a name which can be exported. `Missings.fail` and `Missings.replace` are kept as-is since they are not exported, but should eventually be deprecated in favor of generic iterators under Base.Iterators (possibly called `fail` and `replace`?).

Kind of closes #53.