### PR TITLE
Addressing Breaking Change to Dates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.31
+Compat 0.37.0

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -2,6 +2,9 @@ __precompile__(true)
 module Missings
 
 import Base: *, <, ==, !=, <=, !, +, -, ^, /, &, |, xor
+if VERSION >= v"0.7.0-DEV.2575"
+    import Dates
+end
 using Compat: AbstractRange
 
 export ismissing, missing, missings, Missing, MissingException, levels, skipmissing

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -2,10 +2,7 @@ __precompile__(true)
 module Missings
 
 import Base: *, <, ==, !=, <=, !, +, -, ^, /, &, |, xor
-if VERSION >= v"0.7.0-DEV.2575"
-    import Dates
-end
-using Compat: AbstractRange
+using Compat
 
 export ismissing, missing, missings, Missing, MissingException, levels, skipmissing
 


### PR DESCRIPTION
Addressing [0c0d6cc](https://github.com/JuliaLang/julia/commit/0c0d6cca5d3793eaf6321ef0577afd6ce594a9b5)
If Nulls is getting a version for Julia 0.7 it would need a similar fix (until [Compat](https://github.com/JuliaLang/Compat.jl/pull/413)?).