### PR TITLE
Add allowmissing() and disallowmissing() convenience functions

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -4,7 +4,8 @@ module Missings
 import Base: *, <, ==, !=, <=, !, +, -, ^, /, &, |, xor
 using Compat
 
-export ismissing, missing, missings, Missing, MissingException, levels, skipmissing
+export allowmissing, disallowmissing, ismissing, missing, missings,
+       Missing, MissingException, levels, skipmissing
 
 """
     Missing
@@ -49,6 +50,31 @@ ismissing(::Missing) = true
 missings(dims...) = fill(missing, dims)
 missings(::Type{T}, dims...) where {T >: Missing} = fill!(Array{T}(dims), missing)
 missings(::Type{T}, dims...) where {T} = fill!(Array{Union{T, Missing}}(dims), missing)
+
+"""
+    allowmissing(x::AbstractArray)
+
+Return an array equal to `x` allowing for [`missing`](@ref) values,
+i.e. with an element type equal to `Union{eltype(x), Missing}`.
+
+When possible, the result will share memory with `x` (as with [`convert`](@ref)).
+
+See also: [`disallowmissing`](@ref)
+"""
+allowmissing(x::AbstractVector{T}) where {T} = convert(AbstractArray{Union{T, Missing}}, x)
+
+"""
+    disallowmissing(x::AbstractArray)
+
+Return an array equal to `x` not allowing for [`missing`](@ref) values,
+i.e. with an element type equal to `Missings.T(eltype(x))`.
+
+When possible, the result will share memory with `x` (as with [`convert`](@ref)).
+If `x` contains missing values, a `MethodError` is thrown.
+
+See also: [`allowmissing`](@ref)
+"""
+disallowmissing(x::AbstractVector{T}) where {T} = convert(AbstractArray{Missings.T(T)}, x)
 
 Base.promote_rule(::Type{T}, ::Type{Missing}) where {T} = Union{T, Missing}
 Base.promote_rule(::Type{T}, ::Type{Union{S,Missing}}) where {T,S} = Union{promote_type(T, S), Missing}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,6 +244,24 @@ using Base.Test, Missings, Compat
     @test missings(Union{Int, Missing}, 1, 2) isa Matrix{Union{Int, Missing}}
     @test Union{Int, Missing}[1,2,3] == (Union{Int, Missing})[1,2,3]
 
+    @test allowmissing([1]) == [1]
+    @test allowmissing([1]) isa AbstractVector{Union{Int, Missing}}
+    @test allowmissing(Any[:a]) == [:a]
+    @test allowmissing(Any[:a]) isa AbstractVector{Any}
+    @test isequal(allowmissing([1, missing]), [1, missing])
+    @test allowmissing([1, missing]) isa AbstractVector{Union{Int, Missing}}
+    @test isequal(allowmissing([missing]), [missing])
+    @test allowmissing([missing]) isa AbstractVector{Missing}
+
+    @test disallowmissing(Union{Int, Missing}[1]) == [1]
+    @test disallowmissing(Union{Int, Missing}[1]) isa AbstractVector{Int}
+    @test disallowmissing([1]) == [1]
+    @test disallowmissing([1]) isa AbstractVector{Int}
+    @test disallowmissing(Any[:a]) == [:a]
+    @test disallowmissing(Any[:a]) isa AbstractVector{Any}
+    @test_throws MethodError disallowmissing([1, missing])
+    @test_throws MethodError disallowmissing([missing])
+
     @test convert(Union{Int, Missing}, 1.0) == 1
 
     # AbstractArray{>:Missing}


### PR DESCRIPTION
As requested by several people, given that the convert() call is complex
and not easy to discover.

Fixes https://github.com/JuliaData/Missings.jl/issues/60.