### PR TITLE
Use Base.Missing on Julia 0.7

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,9 @@ using Base.Test, Missings, Compat
                             identity, zero, one, oneunit,
                             iseven, isodd, ispow2,
                             isfinite, isinf, isnan, iszero,
-                            isinteger, isreal, isimag,
+                            isinteger, isreal,
                             isempty, transpose, ctranspose, float]
+    VERSION < v"0.7.0-DEV" && push!(elementary_functions, isimag)
 
     rounding_functions = [ceil, floor, round, trunc]
 


### PR DESCRIPTION
Adapt to https://github.com/JuliaLang/julia/pull/24653. Tests still fail on 0.7 due to a `promote_type` bug in Julia, but most features work.