### PR TITLE
Allow use of `missings` with a dims Tuple

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -4,7 +4,7 @@ module Missings
 using Compat
 
 export allowmissing, disallowmissing, ismissing, missing, missings,
-       Missing, MissingException, levels, coalesce 
+       Missing, MissingException, levels, coalesce
 
 if VERSION < v"0.7.0-DEV.2762"
     """
@@ -216,9 +216,11 @@ T(::Type{T1}) where {T1} = T1
 T(::Type{Any}) = Any
 
 # vector constructors
-missings(dims...) = fill(missing, dims)
-missings(::Type{T}, dims...) where {T >: Missing} = fill!(Array{T}(uninitialized, dims), missing)
-missings(::Type{T}, dims...) where {T} = fill!(Array{Union{T, Missing}}(uninitialized, dims), missing)
+missings(dims::Dims) = fill(missing, dims)
+missings(::Type{T}, dims::Dims) where {T >: Missing} = fill!(Array{T}(uninitialized, dims), missing)
+missings(::Type{T}, dims::Dims) where {T} = fill!(Array{Union{T, Missing}}(uninitialized, dims), missing)
+missings(dims::Integer...) = missings(dims)
+missings(::Type{T}, dims::Integer...) where {T} = missings(T, dims)
 
 """
     allowmissing(x::AbstractArray)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,8 +263,12 @@ using Compat.Test, Compat.SparseArrays, Missings, Compat
     @test isequal(missings(Union{Int, Missing}, 1, 2), [missing missing])
     @test missings(Union{Int, Missing}, 1, 2) isa Matrix{Union{Int, Missing}}
     @test Union{Int, Missing}[1,2,3] == (Union{Int, Missing})[1,2,3]
-    @test isequal(missings(Int, (1, 2)), [missing missing])
-    @test isequal(missings((1, 2)), [missing missing])
+    x = missings(Int, (1, 2))
+    @test isa(x, Matrix{Union{Int, Missing}})
+    @test isequal(x, [missing missing])
+    x = missings((1, 2))
+    @test isa(x, Matrix{Missing})
+    @test isequal(x, [missing missing])
 
     @test allowmissing([1]) == [1]
     @test allowmissing([1]) isa AbstractVector{Union{Int, Missing}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,8 @@ using Compat.Test, Compat.SparseArrays, Missings, Compat
     @test isequal(missings(Union{Int, Missing}, 1, 2), [missing missing])
     @test missings(Union{Int, Missing}, 1, 2) isa Matrix{Union{Int, Missing}}
     @test Union{Int, Missing}[1,2,3] == (Union{Int, Missing})[1,2,3]
+    @test isequal(missings(Int, (1, 2)), [missing missing])
+    @test isequal(missings((1, 2)), [missing missing])
 
     @test allowmissing([1]) == [1]
     @test allowmissing([1]) isa AbstractVector{Union{Int, Missing}}


### PR DESCRIPTION
Behaviour before this PR:
```julia
julia> zeros((2, 3))
2×3 Array{Float64,2}:
 0.0  0.0  0.0
 0.0  0.0  0.0

julia> missings((2, 3))
ERROR: MethodError: no method matching fill(::Missings.Missing, ::Tuple{Tuple{Int64,Int64}})
...
```