### PR TITLE
Define round(::Type{>:Missing}, x) and similar functions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,7 @@ using Compat.Test, Compat.SparseArrays, Missings, Compat
         @test ismissing(f(missing, 1))
         @test ismissing(f(missing, 1, 1))
         @test ismissing(f(Union{Int, Missing}, missing))
+        @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
     end
 


### PR DESCRIPTION
We currently define `round(::Type{>:Missing}, ::Missing)`, but not the corresponding method
for non-missing inputs was missing, making it basically useless. Implements functionality
available on Julia 0.7.

See https://github.com/JuliaLang/julia/pull/25762.