### PR TITLE
Updating the version of Compat to v0.45.0

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.37.0
+Compat 0.45.0


### PR DESCRIPTION
As suggested by @andreasnoack in this comment (https://github.com/JuliaData/Missings.jl/commit/a067a4b13c6d1266297550dad79670bb9ac05345#commitcomment-27629232), this package uses `Compat.IteratorSize` which was introduced in Compat v0.45.0, hence updating the version of Compat in the REQUIRE file.