### PR TITLE
Use typesubtract for Missings.T()

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -210,10 +210,11 @@ end
     Base.adjoint(::Missing) = missing
 end
 
-T(::Type{Union{T1, Missing}}) where {T1} = T1
-T(::Type{Missing}) = Union{}
-T(::Type{T1}) where {T1} = T1
-T(::Type{Any}) = Any
+if VERSION > v"0.7.0-DEV.3420"
+    T(::Type{S}) where {S} = Core.Compiler.typesubtract(S, Missing)
+else
+    T(::Type{S}) where {S} = Core.Inference.typesubtract(S, Missing)
+end
 
 # vector constructors
 missings(dims::Dims) = fill(missing, dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,7 @@ using Compat, Compat.Test, Compat.SparseArrays, Compat.InteractiveUtils, Missing
     @test Missings.T(Union{Int, Missing}) == Int
     @test Missings.T(Any) == Any
     @test Missings.T(Missing) == Union{}
+    @test Missings.T(Union{Array{Int}, Missing}) == Array{Int}
 
     @test isequal(missings(1), [missing])
     @test isequal(missings(Int, 1), [missing])


### PR DESCRIPTION
It works in all cases where the old method works, but also fixes more cases, and works around a Julia bug which completely breaks the current definition in Julia 0.7.

Fixes https://github.com/JuliaData/Missings.jl/issues/80.

Cc: @iamed2