### PR TITLE
Partially revert use of typesubtract on Julia 0.6

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -225,6 +225,9 @@ end
 if VERSION > v"0.7.0-DEV.3420"
     T(::Type{S}) where {S} = Core.Compiler.typesubtract(S, Missing)
 else
+    T(::Type{Union{T1, Missing}}) where {T1} = T1
+    T(::Type{Missing}) = Union{}
+    T(::Type{Any}) = Any
     T(::Type{S}) where {S} = Core.Inference.typesubtract(S, Missing)
 end
 


### PR DESCRIPTION
`typesubtract` has some bugs on Julia 0.6 which trigger problems with CategoricalArrays and DataFrames. For example, this fails: `convert(CategoricalArray{Union{Int16, Missing}}, categorical(Int[1]))`
See also JuliaData/DataFrames.jl#1390.