### PR TITLE
Test `Any` case, where `fill!` syntax required

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,8 +88,10 @@ using Test, SparseArrays, Missings
     @test Missings.T(Union{Array{Int}, Missing}) == Array{Int}
 
     @test isequal(missings(1), [missing])
+    @test isequal(missings(Any, 1), [missing])
     @test isequal(missings(Int, 1), [missing])
     @test missings(Int, 1) isa Vector{Union{Int, Missing}}
+    @test missings(Any, 1) isa Vector{Union{Any, Missing}}
     @test isequal(missings(Union{Int, Missing}, 1, 2), [missing missing])
     @test missings(Union{Int, Missing}, 1, 2) isa Matrix{Union{Int, Missing}}
     @test Union{Int, Missing}[1,2,3] == (Union{Int, Missing})[1,2,3]


### PR DESCRIPTION
I wondered why we use `fill!` in `missings` 
https://github.com/JuliaData/Missings.jl/blob/3ac53e982337b5c3e9ab625f69e3b5454b89d422/src/Missings.jl#L13
and didn't just define it as `Array{Union{T, Missing}}(undef, dims)`

Turns out `T = Any` is the only case that definition wouldn't work for (AFAIK).
So this PR adds tests for that case :)

```julia
julia> Array{Union{Int, Missing}}(undef, (2, 3))
2×3 Array{Union{Missing, Int64},2}:
 missing  missing  missing
 missing  missing  missing

julia> struct F end

julia> Array{Union{F, Missing}}(undef, (2, 3))
2×3 Array{Union{Missing, F},2}:
 missing  missing  missing
 missing  missing  missing

julia> Array{Union{Any, Missing}}(undef, (2, 3))
2×3 Array{Any,2}:
 #undef  #undef  #undef
 #undef  #undef  #undef
```
