### PR TITLE
Deprecate `Missings.T` -> `Missings.nonmissingtype`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
+  - 1.2
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,10 +82,10 @@ using Test, SparseArrays, Missings
     @test isempty(levels([missing]))
     @test isempty(levels([]))
 
-    @test Missings.T(Union{Int, Missing}) == Int
-    @test Missings.T(Any) == Any
-    @test Missings.T(Missing) == Union{}
-    @test Missings.T(Union{Array{Int}, Missing}) == Array{Int}
+    @test Missings.nonmissingtype(Union{Int, Missing}) == Int
+    @test Missings.nonmissingtype(Any) == Any
+    @test Missings.nonmissingtype(Missing) == Union{}
+    @test Missings.nonmissingtype(Union{Array{Int}, Missing}) == Array{Int}
 
     @test isequal(missings(1), [missing])
     @test isequal(missings(Int, 1), [missing])
@@ -143,4 +143,11 @@ using Test, SparseArrays, Missings
     @test passmissing((x,y)->"$x $y")(1, 2) == "1 2"
     @test isequal(passmissing((x,y)->"$x $y")(missing), missing)
     @test_throws ErrorException passmissing(string)(missing, base=2)
+
+    @testset "deprecated" begin
+        # The (unexported) `Missings.T` was deprecated to `Missings.nonmissingtype`
+        for x in (Union{Int, Missing}, Any, Missing, Union{Array{Int}, Missing})
+            @test Missings.T(x) == Missings.nonmissingtype(x)
+        end
+    end
 end


### PR DESCRIPTION
- closes #101 
- fits with Base's naming -- [nonmissingtype is exported from Base in Julia 1.3](https://github.com/JuliaLang/julia/commit/1e6d5f1a5b3041eba854412afa813b903182fa5b)
- Base.nonmissingtype exactly matches the definition of Missings.T ([since Julia 1.2](https://github.com/JuliaLang/julia/commit/98673b5a0f4efd72dd401b603745c70193e1f64b))
- Adds CI testing on 1.2 and 1.3
- Missings.T was not exported, so Missings.nonmissingtype is not exported
- Let me know if and how I should bump the version number