### PR TITLE
Bump version; remove deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,10 +2,6 @@ name = "Missings"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 version = "0.4.1"
 
-[deps]
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 [compat]
 julia = "1"
 
@@ -14,5 +10,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
-
+test = ["Test", "SparseArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Missings"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.1"
+version = "0.4.2"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
So we can tag a new release!

I don't believe there have been any breaking changes ([see changes here](https://github.com/JuliaData/Missings.jl/compare/v0.4.0...master))

- Tests were cleaned up (https://github.com/JuliaData/Missings.jl/pull/95) and some added (https://github.com/JuliaData/Missings.jl/pull/100)
- `Missings.T` deprecated to `Missings.nonmissingtype` (https://github.com/JuliaData/Missings.jl/pull/102)
- `passmissing` definition generalised, but no tests needed changing / things that used to work all still work (https://github.com/JuliaData/Missings.jl/pull/99)