### PR TITLE
Use levels from DataAPI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,13 @@
 name = "Missings"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.2"
+version = "0.4.3"
+
+[deps]
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 
 [compat]
 julia = "1"
+DataAPI = "1.1"
 
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -150,27 +150,7 @@ end
     return (v::eltype(itr), s)
 end
 
-"""
-    levels(x)
-
-Return a vector of unique values which occur or could occur in collection `x`,
-omitting `missing` even if present. Values are returned in the preferred order
-for the collection, with the result of [`sort`](@ref) as a default.
-
-Contrary to [`unique`](@ref), this function may return values which do not
-actually occur in the data, and does not preserve their order of appearance in `x`.
-"""
-function levels(x)
-    T = nonmissingtype(eltype(x))
-    levs = convert(AbstractArray{T}, filter!(!ismissing, unique(x)))
-    if hasmethod(isless, Tuple{T, T})
-        try
-            sort!(levs)
-        catch
-        end
-    end
-    levs
-end
+const levels = DataAPI.levels
 
 struct PassMissing{F} <: Function
     f::F

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -12,6 +12,8 @@ else
     using Base: nonmissingtype
 end
 
+using DataAPI: levels
+
 @deprecate T nonmissingtype false
 
 # vector constructors

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -12,7 +12,7 @@ else
     using Base: nonmissingtype
 end
 
-using DataAPI: levels
+import DataAPI
 
 @deprecate T nonmissingtype false
 


### PR DESCRIPTION
Keep exporting it for now: if we added a deprecation, it would be triggered even when people call levels after loading CategoricalArrays or DataFrames.

Depends on JuliaData/DataAPI.jl#12.