### PR TITLE
Update version from `0.4.3` to `0.5.0`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Missings"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.3"
+version = "0.5.0"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Missings"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.5.0"
+version = "0.4.4"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"


### PR DESCRIPTION
I think adding a new function feature like `skipmissings` qualifies as a `0.4` to `0.5` jump according to SemVer since code written for `0.4.4` is expected to work with `0.4.3`. 