### PR TITLE
Reexport `levels` instead of defining object

### DIFF
--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -12,7 +12,7 @@ else
     using Base: nonmissingtype
 end
 
-import DataAPI
+using DataAPI: levels
 
 # vector constructors
 missings(dims::Dims) = fill(missing, dims)
@@ -174,8 +174,6 @@ Base.@propagate_inbounds function Base.getindex(itr::EachFailMissing, I...)
     v === missing && throw(MissingException("the value at index $I is missing"))
     return v
 end
-
-const levels = DataAPI.levels
 
 struct PassMissing{F} <: Function
     f::F


### PR DESCRIPTION
For some reason this confuses Documenter into thinking that it's a separate function from `DataAPI.levels`. Fixes the Documenter failure at https://github.com/JuliaData/CategoricalArrays.jl/pull/367.

I have no idea why I didn't use that approach originally (https://github.com/JuliaData/Missings.jl/pull/108).