### PR TITLE
Implementing order functions where missings is the smallest value

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ This package provides additional functionality for working with `missing` values
 - `Missings.replace` to wrap a collection in a (possibly indexable) iterator replacing `missing` with another value
 - `Missings.fail` to wrap a collection in a (possibly indexable) iterator throwing an error if `missing` is encountered
 - `skipmissings` to loop through a collection of iterators excluding indices where any iterators are `missing`
-- `missingsmallest(f)` to create a partial order function that behaves as `f` and making `missing` the smallest value
-- `missingsless` the standard `isless` function modified so that `missing` is less than any other element
+- `missingsmallest(f)` to create a partial order function that treats `missing` as the smallest value and otherwise behaves like `f`
+- `missingsless` the standard `isless` function modified to treat `missing` as the smallest value rather than the largest one
 
 ## Contributing and Questions
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This package provides additional functionality for working with `missing` values
 - `Missings.replace` to wrap a collection in a (possibly indexable) iterator replacing `missing` with another value
 - `Missings.fail` to wrap a collection in a (possibly indexable) iterator throwing an error if `missing` is encountered
 - `skipmissings` to loop through a collection of iterators excluding indices where any iterators are `missing`
+- `missingsmallest(f)` to create a partial order function that behaves as `f` and making `missing` the smallest value
+- `missingsless` the standard `isless` function modified so that `missing` is less than any other element
 
 ## Contributing and Questions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package provides additional functionality for working with `missing` values
 - `Missings.fail` to wrap a collection in a (possibly indexable) iterator throwing an error if `missing` is encountered
 - `skipmissings` to loop through a collection of iterators excluding indices where any iterators are `missing`
 - `missingsmallest(f)` to create a partial order function that treats `missing` as the smallest value and otherwise behaves like `f`
-- `missingsmallest` the standard `isless` function modified to treat `missing` as the smallest value rather than the largest one
+- `missingsmallest`: the standard `isless` function modified to treat `missing` as the smallest value rather than the largest one
 
 ## Contributing and Questions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This package provides additional functionality for working with `missing` values
 - `Missings.fail` to wrap a collection in a (possibly indexable) iterator throwing an error if `missing` is encountered
 - `skipmissings` to loop through a collection of iterators excluding indices where any iterators are `missing`
 - `missingsmallest(f)` to create a partial order function that treats `missing` as the smallest value and otherwise behaves like `f`
-- `missingsless` the standard `isless` function modified to treat `missing` as the smallest value rather than the largest one
+- `missingsmallest` the standard `isless` function modified to treat `missing` as the smallest value rather than the largest one
 
 ## Contributing and Questions
 

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -534,8 +534,7 @@ y)` function. This is equivalent to `missingsmallest(isless)(x, y)`.
 
 # Examples
 ```
-julia> lengthmissing = passmissing(length)
-julia> isshorter = missingsmallest((s1, s2) -> isless(lengthmissing(s1), lengthmissing(s2)))
+julia> isshorter = missingsmallest((s1, s2) -> isless(length(s1), length(s2)))
 julia> isshorter("short", "longstring")
 true
 
@@ -554,8 +553,8 @@ missingsmallest(f) = MissingSmallest(f)
 The standard partial order `isless` modified so that `missing` is always the
 smallest possible value:
 - If neither argument is `missing`, the function behaves exactly as `isless`.
-- If `x` is `missing` the result will be `true` regardless of the value of `y`.
 - If `y` is `missing` the result will be `false` regardless of the value of `x`.
+- If `x` is `missing` the result will be `true` unless `y` is `missing`.
 
 See also the 1-argument method which takes a partial ordering function (like
 `isless`) and modifies it to treat `missing` as explained above. These functions
@@ -564,8 +563,7 @@ first. This is useful in particular so that when sorting in reverse order
 missing values appear at the end.
 
 # Examples
-```
-julia> v = [missing, 10, missing, 1, 2]
+```jldoctest
 julia> sort(v, lt=missingsmallest)
 
 5-element Vector{Union{Missing, Int64}}:
@@ -591,8 +589,7 @@ julia> missingsmallest(-Inf, missing)
 false
 
 julia> missingsmallest(missing, missing)
-true
-```
+false
 """
 missingsmallest(x, y) = missingsmallest(isless)(x, y)
 

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -528,17 +528,21 @@ words, return a modified version of the partial order function `f` such that
 `missing` is the smallest possible value, and all other non-`missing` values are
 compared according to `f`.
 
-The traditional `isless` function modified to treat `missing` as the smallest
-value can be accessed by using the 2-argument `missingsmallest(x, y)` function,
-see [`missingsmallest`](@ref).
+The behavior of the standard `isless` function modified to treat `missing` as
+the smallest value can be obtained by calling the 2-argument `missingsmallest(x,
+y)` function. This is equivalent to `missingsmallest(isless)(x, y)`.
 
 # Examples
 ```
-julia> ismuchless = missingsmallest((x, y) -> isless(x, 10*y))
-julia> ismuchless(1, 100)
+julia> lengthmissing = passmissing(length)
+julia> isshorter = missingsmallest((s1, s2) -> isless(lengthmissing(s1), lengthmissing(s2)))
+julia> isshorter("short", "longstring")
 true
 
-julia> ismuchless(-Inf, missing)
+julia> isshorter("longstring", "short")
+false
+
+julia> isshorter("", missing) # Is shorter than length 0?
 false
 ```
 """

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -528,12 +528,17 @@ words, returns a modified version of the partial order function `f` such that
 `missing` is the smallest possible value, and all other non-`missing` values are
 compared according to `f`.
 
+The traditional `isless` function modified to treat `missing` as the smallest
+value can be accessed by using the 2-argument `missingsmallest(x, y)` function,
+see [`missingsmallest`](@ref).
+
 # Examples
 ```
-julia> missingsmallest((x, y) -> isless(x, 10*y))(missing, Inf)
+julia> ismuchless = missingsmallest((x, y) -> isless(x, 10*y))
+julia> ismuchless(1, 100)
 true
 
-julia> missingsless(-Inf, missing)
+julia> ismuchless(-Inf, missing)
 false
 ```
 """
@@ -548,10 +553,10 @@ smallest possible value. The expected behaviour is the following:
 - If `x` is `missing` the result will be `true` regardless of the value of `y`.
 - If `y` is `missing` the result will be `false` regardless of the value of `x`.
 
-See also [`missingsmallest`](@ref), which is equivalent to using
-`missingsmallest(isless)`. These functions can be used together with sorting
-functions such that the first elements of the newly sorted Array are placed
-first.
+See also [`missingsmallest`](@ref), the 1-argument function which takes a
+partial ordering function (like `isless`) and modifies it to treat `missing` as
+explained above. These functions can be used together with sorting functions
+such that the first elements of the newly sorted Array are placed first.
 
 # Examples
 ```

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -2,7 +2,7 @@ module Missings
 
 export allowmissing, disallowmissing, ismissing, missing, missings,
        Missing, MissingException, levels, coalesce, passmissing, nonmissingtype,
-       skipmissings, emptymissing
+       skipmissings, emptymissing, missingsmallest, missingsless
 
 using Base: ismissing, missing, Missing, MissingException
 
@@ -513,5 +513,33 @@ julia> emptymissing(first)([1], 2)
 ```
 """
 emptymissing(f) = (x, args...; kwargs...) -> isempty(x) ? missing : f(x, args...; kwargs...)
+
+# Variant of `isless` where `missing` is the smallest value
+"""
+    missingsmallest(f::Function)
+
+Creates a function of two arguments `x` and `y` that tests whether `x` is less
+than `y` such that `missing` is always less than the other argument. In other
+words, modifies the partial order function `f` such that `missing` is the
+smallest possible value, and all other non-`missing` values are compared
+according to `f`.
+
+See also: [`missingsless`](@ref), the standard order where `missing` is the
+smallest possible value.
+
+# Examples
+```
+julia> missingsmallest(isless)(missing, Inf)
+true
+
+julia> missingsless(-Inf, missing)
+false
+```
+"""
+missingsmallest(f) = (x, y) -> ismissing(y) ? false : ismissing(x) ? true : f(x, y)
+
+" The standard partial order `isless` modified so that `missing` is always the
+smallest possible value."
+const missingsless = missingsmallest(isless)
 
 end # module

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -541,7 +541,7 @@ true
 julia> isshorter("longstring", "short")
 false
 
-julia> isshorter("", missing) # Is shorter than length 0?
+julia> isshorter("", missing)
 false
 ```
 """

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -534,7 +534,8 @@ y)` function. This is equivalent to `missingsmallest(isless)(x, y)`.
 
 # Examples
 ```
-julia> isshorter = missingsmallest((s1, s2) -> isless(length(s1), length(s2)))
+julia> isshorter = missingsmallest((s1, s2) -> isless(length(s1), length(s2)));
+
 julia> isshorter("short", "longstring")
 true
 
@@ -574,7 +575,6 @@ julia> sort(v, lt=missingsmallest)
  10
 
 julia> sort(v, lt=missingsmallest, rev=true)
-
 5-element Vector{Union{Missing, Int64}}:
  10
   2

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -518,26 +518,51 @@ emptymissing(f) = (x, args...; kwargs...) -> isempty(x) ? missing : f(x, args...
     missingsmallest(f)
 
 Creates a function of two arguments `x` and `y` that tests whether `x` is less
-than `y` such that `missing` is always less than the other argument. In other
-words, modifies the partial order function `f` such that `missing` is the
-smallest possible value, and all other non-`missing` values are compared
-according to `f`.
+than `y` such that `missing` is always less than the other argument. In other 
+words, returns a modified version of the partial order function `f` such that
+`missing` is the smallest possible value, and all other non-`missing` values are
+compared according to `f`.
 
 See also: [`missingsless`](@ref), equivalent to `missingsmallest(isless)`
 
 # Examples
 ```
-julia> missingsmallest(isless)(missing, Inf)
-true
+julia> missingsmallest(Base.isgreater)(missing, Inf)
+false
 
 julia> missingsless(-Inf, missing)
 false
 ```
 """
-missingsmallest(f) = (x, y) -> ismissing(y) ? false : ismissing(x) ? true : f(x, y)
+@inline missingsmallest(f) = (x, y) -> ismissing(y) ? false : ismissing(x) ? true : f(x, y)
 
 " The standard partial order `isless` modified so that `missing` is always the
 smallest possible value."
-const missingsless = missingsmallest(isless)
+
+"""
+    missingsless(x, y)
+
+The standard partial order `isless` modified so that `missing` is always the
+smallest possible value. The expected behaviour is the following:
+- If neither argument is `missing`, the function behaves exactly as `isless`.
+- If `x` is `missing` the result will be `true` regardless of the value of `y`.
+- If `y` is `missing` the result will be `false` regardless of the value of `x`.
+
+See also [`missingsmallest`](@ref), which modifies a partial order function and
+yields a function that behaves as the expected behaviour outlined above.
+
+# Examples
+```
+julia> missingsless(missing, Inf)
+true
+
+julia> missingsless(-Inf, missing)
+false
+
+julia> missingsless(missing, missing)
+true
+```
+"""
+missingsless(x, y) = missingsmallest(isless)(x, y)
 
 end # module

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -566,7 +566,6 @@ missing values appear at the end.
 # Examples
 ```jldoctest
 julia> sort(v, lt=missingsmallest)
-
 5-element Vector{Union{Missing, Int64}}:
    missing
    missing

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -514,9 +514,8 @@ julia> emptymissing(first)([1], 2)
 """
 emptymissing(f) = (x, args...; kwargs...) -> isempty(x) ? missing : f(x, args...; kwargs...)
 
-# Variant of `isless` where `missing` is the smallest value
 """
-    missingsmallest(f::Function)
+    missingsmallest(f)
 
 Creates a function of two arguments `x` and `y` that tests whether `x` is less
 than `y` such that `missing` is always less than the other argument. In other
@@ -524,8 +523,7 @@ words, modifies the partial order function `f` such that `missing` is the
 smallest possible value, and all other non-`missing` values are compared
 according to `f`.
 
-See also: [`missingsless`](@ref), the standard order where `missing` is the
-smallest possible value.
+See also: [`missingsless`](@ref), equivalent to `missingsmallest(isless)`
 
 # Examples
 ```

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -522,9 +522,9 @@ end
 """
     missingsmallest(f)
 
-Creates a function of two arguments `x` and `y` that tests whether `x` is less
+Return a function of two arguments `x` and `y` that tests whether `x` is less
 than `y` such that `missing` is always less than the other argument. In other 
-words, returns a modified version of the partial order function `f` such that
+words, return a modified version of the partial order function `f` such that
 `missing` is the smallest possible value, and all other non-`missing` values are
 compared according to `f`.
 
@@ -548,26 +548,37 @@ missingsmallest(f) = MissingSmallest(f)
     missingsmallest(x, y)
 
 The standard partial order `isless` modified so that `missing` is always the
-smallest possible value. The expected behaviour is the following:
+smallest possible value:
 - If neither argument is `missing`, the function behaves exactly as `isless`.
 - If `x` is `missing` the result will be `true` regardless of the value of `y`.
 - If `y` is `missing` the result will be `false` regardless of the value of `x`.
 
-See also [`missingsmallest`](@ref), the 1-argument function which takes a
-partial ordering function (like `isless`) and modifies it to treat `missing` as
-explained above. These functions can be used together with sorting functions
-such that the first elements of the newly sorted Array are placed first.
+See also the 1-argument method which takes a partial ordering function (like
+`isless`) and modifies it to treat `missing` as explained above. These functions
+can be used together with sorting functions so that missing values are sorted
+first. This is useful in particular so that when sorting in reverse order
+missing values appear at the end.
 
 # Examples
 ```
 julia> v = [missing, 10, missing, 1, 2]
 julia> sort(v, lt=missingsmallest)
+
 5-element Vector{Union{Missing, Int64}}:
    missing
    missing
   1
   2
  10
+
+julia> sort(v, lt=missingsmallest, rev=true)
+
+5-element Vector{Union{Missing, Int64}}:
+ 10
+  2
+  1
+   missing
+   missing
 
 julia> missingsmallest(missing, Inf)
 true

--- a/src/Missings.jl
+++ b/src/Missings.jl
@@ -527,8 +527,8 @@ See also: [`missingsless`](@ref), equivalent to `missingsmallest(isless)`
 
 # Examples
 ```
-julia> missingsmallest(Base.isgreater)(missing, Inf)
-false
+julia> missingsmallest((x, y) -> isless(x, 10*y))(missing, Inf)
+true
 
 julia> missingsless(-Inf, missing)
 false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,7 +158,7 @@ struct CubeRooter end
     @test disallowmissing(Any[:a]) == [:a]
     @test disallowmissing(Any[:a]) isa AbstractVector{Any}
     @test_throws MethodError disallowmissing([1, missing])
-    @test_throws MethodError disallowmissing([missing])
+    @test_throws Union{MethodError, ArgumentError} disallowmissing([missing])
 
     @test disallowmissing(Union{Int, Missing}[1 1]) == [1 1]
     @test disallowmissing(Union{Int, Missing}[1 1]) isa AbstractArray{Int, 2}
@@ -167,7 +167,7 @@ struct CubeRooter end
     @test disallowmissing([:a 1]) == [:a 1]
     @test disallowmissing([:a 1]) isa AbstractArray{Any, 2}
     @test_throws MethodError disallowmissing([1 missing])
-    @test_throws MethodError disallowmissing([missing missing])
+    @test_throws Union{MethodError, MethodError} disallowmissing([missing missing])
 
     # Lifting
     ## functor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -167,7 +167,7 @@ struct CubeRooter end
     @test disallowmissing([:a 1]) == [:a 1]
     @test disallowmissing([:a 1]) isa AbstractArray{Any, 2}
     @test_throws MethodError disallowmissing([1 missing])
-    @test_throws Union{MethodError, MethodError} disallowmissing([missing missing])
+    @test_throws Union{MethodError, ArgumentError} disallowmissing([missing missing])
 
     # Lifting
     ## functor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,6 +263,13 @@ end
     @test missingsless(missing, missing) == false
     @test missingsless(3, 4) == true
     @test missingsless(-Inf, Inf) == true 
+
+    ≪(x, y) = isless(10*x, y) # "Much greater than" function
+    missings_ll = missingsmallest(≪)
+    @test missings_ll(missing, Inf) == true
+    @test missings_ll(-Inf, missing) == false
+    @test missings_ll(1, 2) == false
+    @test missings_ll(1, 200) == true
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,11 +258,11 @@ struct CubeRooter end
 end
 
 @testset "missingsmallest" begin
-    @test missingsless(missing, Inf) == true
-    @test missingsless(-Inf, missing) == false
-    @test missingsless(missing, missing) == false
-    @test missingsless(3, 4) == true
-    @test missingsless(-Inf, Inf) == true 
+    @test missingsmallest(missing, Inf) == true
+    @test missingsmallest(-Inf, missing) == false
+    @test missingsmallest(missing, missing) == false
+    @test missingsmallest(3, 4) == true
+    @test missingsmallest(-Inf, Inf) == true 
 
     ≪(x, y) = isless(10*x, y) # "Much greater than" function
     missings_ll = missingsmallest(≪)
@@ -270,6 +270,9 @@ end
     @test missings_ll(-Inf, missing) == false
     @test missings_ll(1, 2) == false
     @test missings_ll(1, 200) == true
+
+    @test_throws MethodError missingsmallest(isless)(isless)
+    @test missingsmallest !== missingsmallest(isless)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,4 +257,11 @@ struct CubeRooter end
     @test emptymissing(fun)(3, 1, c=2) == (1, 2)
 end
 
+@testset "missingsmallest" begin
+    @test missingsless(missing, Inf) == true
+    @test missingsless(-Inf, missing) == false
+    @test missingsless(3, 4) == true
+    @test missingsless(-Inf, Inf) == true 
+end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,8 +273,7 @@ end
     @test missingsmallest(missing, (1e3, 1e4)) == true
     
     # Compare strings by length, not lexicographically
-    lengthmissing = passmissing(length)
-    isshorter = missingsmallest((s1, s2) -> isless(lengthmissing(s1), lengthmissing(s2)))
+    isshorter = missingsmallest((s1, s2) -> isless(length(s1), length(s2)))
     @test isshorter("short", "longstring") == true
     @test isshorter("longstring", "short") == false
     @test isshorter(missing, "short") == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,12 +264,21 @@ end
     @test missingsmallest(3, 4) == true
     @test missingsmallest(-Inf, Inf) == true 
 
-    ≪(x, y) = isless(10*x, y) # "Much greater than" function
-    missings_ll = missingsmallest(≪)
-    @test missings_ll(missing, Inf) == true
-    @test missings_ll(-Inf, missing) == false
-    @test missings_ll(1, 2) == false
-    @test missings_ll(1, 200) == true
+    @test missingsmallest("a", "b") == true
+    @test missingsmallest("short", missing) == false
+    @test missingsmallest(missing, "") == true
+
+    @test missingsmallest((1, 2), (3, 4)) == true
+    @test missingsmallest((3, 4), (1, 2)) == false
+    @test missingsmallest(missing, (1e3, 1e4)) == true
+    
+    # Compare strings by length, not lexicographically
+    lengthmissing = passmissing(length)
+    isshorter = missingsmallest((s1, s2) -> isless(lengthmissing(s1), lengthmissing(s2)))
+    @test isshorter("short", "longstring") == true
+    @test isshorter("longstring", "short") == false
+    @test isshorter(missing, "short") == true
+    @test isshorter("", missing) == false
 
     @test_throws MethodError missingsmallest(isless)(isless)
     @test missingsmallest !== missingsmallest(isless)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,7 @@ end
 @testset "missingsmallest" begin
     @test missingsless(missing, Inf) == true
     @test missingsless(-Inf, missing) == false
+    @test missingsless(missing, missing) == false
     @test missingsless(3, 4) == true
     @test missingsless(-Inf, Inf) == true 
 end


### PR DESCRIPTION
As discussed in issue #142, this PR adds a variant of the standard `isless` function where the smallest possible value is `missing`. Furthermore, this PR adds a partial order function `missingsmallest` that takes a partial order function `f` and modifies the order such that `missing` is always less than the other argument.

This PR aims to provide support to resolve issue https://github.com/JuliaData/DataFrames.jl/issues/2267 at DataFrames.jl