### PR TITLE
Use 'min' Julia version in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,20 +40,3 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-#  docs:
-#    name: Documentation
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v6
-#      - uses: julia-actions/setup-julia@v2
-#        with:
-#          version: '1'
-#      - run: |
-#          julia --project=docs -e '
-#            using Pkg
-#            Pkg.develop(PackageSpec(path=pwd()))
-#            Pkg.instantiate()'
-#      - run: julia --project=docs docs/make.jl
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - 'min'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:


### PR DESCRIPTION
Make the CI test on lowest supported version as stated in Project.toml. Should also serve as an indicator if the minimum Julia version needs to be bumped